### PR TITLE
Add benchmark.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 node_modules
-react-dom.development.*
-react-dom.production.min.*
+react-dom.development*
+react-dom.production.min*

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 node_modules
-*.ast
-
+react-dom.development.*
+react-dom.production.min.*

--- a/README.md
+++ b/README.md
@@ -4,16 +4,61 @@ AST, what’s faster?
 To run:
 
 * `git clone {repo}`
-* `node run.js`
+* `npm install`
+* `npm run benchmark-prod`
+* `npm run benchmark-dev`
 
 ```sh
-➜  babylon-experiment node run.js
-parse prod: 192.497ms
-parse dev: 194.586ms
-stringify and write prod: 203.352ms
-stringify and write dev: 479.854ms
-require prod ast: 1343.973ms
-require dev ast: 2097.112ms
+➜  babylon-experiment npm run benchmark-prod
+
+> babylon-experiment@1.0.0 benchmark-prod /Users/sashaaickin/code/parse-vs-ast-startup-time
+> node run.js --parse-prod && node run.js --require-ast-prod && node run.js --require-js-prod && node run.js --require-json-prod && node run.js --read-json-prod
+
+parse JS code, prod
+Mean:    73 ms
+Std Dev: 16 ms
+
+require .ast file, prod
+Mean:    183 ms
+Std Dev: 234 ms
+
+require .js file, prod
+Mean:    187 ms
+Std Dev: 233 ms
+
+require .json file, prod
+Mean:    280 ms
+Std Dev: 61 ms
+
+read .json file, prod
+Mean:    256 ms
+Std Dev: 38 ms
+
+➜  babylon-experiment npm run benchmark-dev
+
+> babylon-experiment@1.0.0 benchmark-dev /Users/sashaaickin/code/parse-vs-ast-startup-time
+> node run.js --parse-dev && node run.js --require-ast-dev && node run.js --require-js-dev && node run.js --require-json-dev && node run.js --read-json-dev
+
+parse JS code, dev
+Mean:    78 ms
+Std Dev: 16 ms
+
+require .ast file, dev
+Mean:    395 ms
+Std Dev: 402 ms
+
+require .js file, dev
+Mean:    454 ms
+Std Dev: 465 ms
+
+require .json file, dev
+Mean:    750 ms
+Std Dev: 143 ms
+
+read .json file, dev
+Mean:    638 ms
+Std Dev: 46 ms
+
 ```
 
 Random observation: `JSON.stringify(ast, null, 2)` takes ~5x longer than

--- a/README.md
+++ b/README.md
@@ -12,61 +12,52 @@ To run:
 ➜  babylon-experiment npm run benchmark-prod
 
 > babylon-experiment@1.0.0 benchmark-prod /Users/sashaaickin/code/parse-vs-ast-startup-time
-> node run.js --parse-prod && node run.js --require-ast-prod && node run.js --require-js-prod && node run.js --require-json-prod && node run.js --read-json-prod && node run.js --read-json-fast-prod
+> node run.js --parse-prod && node run.js --require-js-prod && node run.js --require-json-prod && node run.js --read-json-prod && node run.js --read-json-fast-prod
 
-parse JS code, prod
-Mean:    73 ms
-Std Dev: 11 ms
+parse .js code, prod
+Mean:    72 ms
+Std Dev: 14 ms
 
-require .ast file, prod
-Mean:    176 ms
-Std Dev: 223 ms
+require .js AST, prod
+Mean:    181 ms
+Std Dev: 221 ms
 
-require .js file, prod
-Mean:    168 ms
-Std Dev: 204 ms
+require .json AST, prod
+Mean:    282 ms
+Std Dev: 49 ms
 
-require .json file, prod
-Mean:    272 ms
-Std Dev: 63 ms
-
-read .json file, prod
+read .json AST, prod
 Mean:    238 ms
-Std Dev: 17 ms
+Std Dev: 20 ms
 
-read .json file fast parse, prod
-Mean:    249 ms
-Std Dev: 32 ms
+read .json AST fast parse, prod
+Mean:    235 ms
+Std Dev: 19 ms
 
 ➜  babylon-experiment npm run benchmark-dev
 
 > babylon-experiment@1.0.0 benchmark-dev /Users/sashaaickin/code/parse-vs-ast-startup-time
-> node run.js --parse-dev && node run.js --require-ast-dev && node run.js --require-js-dev && node run.js --require-json-dev && node run.js --read-json-dev && node run.js --read-json-fast-dev
+> node run.js --parse-dev && node run.js --require-js-dev && node run.js --require-json-dev && node run.js --read-json-dev && node run.js --read-json-fast-dev
 
-parse JS code, dev
-Mean:    74 ms
-Std Dev: 13 ms
+parse .js code, dev
+Mean:    73 ms
+Std Dev: 15 ms
 
-require .ast file, dev
-Mean:    390 ms
-Std Dev: 415 ms
+require .js AST, dev
+Mean:    372 ms
+Std Dev: 391 ms
 
-require .js file, dev
-Mean:    405 ms
-Std Dev: 405 ms
+require .json AST, dev
+Mean:    910 ms
+Std Dev: 402 ms
 
-require .json file, dev
-Mean:    708 ms
-Std Dev: 73 ms
+read .json AST, dev
+Mean:    636 ms
+Std Dev: 76 ms
 
-read .json file, dev
-Mean:    631 ms
-Std Dev: 58 ms
-
-read .json file fast parse, dev
-Mean:    615 ms
-Std Dev: 62 ms
-
+read .json AST fast parse, dev
+Mean:    623 ms
+Std Dev: 66 ms
 ```
 
 Random observation: `JSON.stringify(ast, null, 2)` takes ~5x longer than

--- a/package.json
+++ b/package.json
@@ -3,9 +3,15 @@
   "version": "1.0.0",
   "main": "index.js",
   "license": "MIT",
+  "scripts": {
+    "benchmark-prod": "node run.js --parse-prod && node run.js --require-ast-prod && node run.js --require-js-prod && node run.js --require-json-prod && node run.js --read-json-prod",
+    "benchmark-dev": "node run.js --parse-dev && node run.js --require-ast-dev && node run.js --require-js-dev && node run.js --require-json-dev && node run.js --read-json-dev"
+  },
   "dependencies": {
     "babel": "^6.23.0",
     "babylon": "^6.16.1",
+    "benchmark": "^2.1.4",
+    "react": "next",
     "react-dom": "next"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "main": "index.js",
   "license": "MIT",
   "scripts": {
-    "benchmark-prod": "node run.js --parse-prod && node run.js --require-ast-prod && node run.js --require-js-prod && node run.js --require-json-prod && node run.js --read-json-prod && node run.js --read-json-fast-prod",
-    "benchmark-dev": "node run.js --parse-dev && node run.js --require-ast-dev && node run.js --require-js-dev && node run.js --require-json-dev && node run.js --read-json-dev && node run.js --read-json-fast-dev"
+    "benchmark-prod": "node run.js --parse-prod && node run.js --require-js-prod && node run.js --require-json-prod && node run.js --read-json-prod && node run.js --read-json-fast-prod",
+    "benchmark-dev": "node run.js --parse-dev && node run.js --require-js-dev && node run.js --require-json-dev && node run.js --read-json-dev && node run.js --read-json-fast-dev"
   },
   "dependencies": {
     "babel": "^6.23.0",

--- a/run.js
+++ b/run.js
@@ -18,96 +18,80 @@ const ReactDOMDev = pathFor('development');
 
 const prod = fs.readFileSync(ReactDOMProd, 'utf8');
 const prodAst = babylon.parse(prod);
-fs.writeFileSync('react-dom.production.min.ast', 'module.exports = ' + JSON.stringify(prodAst) + ';');
 fs.writeFileSync('react-dom.production.min.js', 'module.exports = ' + JSON.stringify(prodAst) + ';');
-fs.writeFileSync('react-dom.production.min.json', JSON.stringify(prodAst));
+fs.writeFileSync('react-dom.production.min-json.json', JSON.stringify(prodAst));
 
 const dev = fs.readFileSync(ReactDOMDev, 'utf8');
 const devAst = babylon.parse(dev);
-fs.writeFileSync('react-dom.development.ast', 'module.exports = ' + JSON.stringify(devAst) + ';');
 fs.writeFileSync('react-dom.development.js', 'module.exports = ' + JSON.stringify(devAst) + ';');
-fs.writeFileSync('react-dom.development.json', JSON.stringify(devAst));
+fs.writeFileSync('react-dom.development-json.json', JSON.stringify(devAst));
 
 
 const benchmarkFns = {
   "parse-prod": {
-    name: "parse JS code, prod",
+    name: "parse .js code, prod",
     fn: () => {
       const prod = fs.readFileSync(ReactDOMProd, 'utf8');
       const prodAst = babylon.parse(prod);
     }
   },
-  "require-ast-prod": {
-    name: "require .ast file, prod",
-    fn: () => {
-      const ast = require('./react-dom.production.min.ast');
-      delete require.cache[require.resolve('./react-dom.production.min.ast')];
-    }
-  },
   "require-js-prod": {
-    name: "require .js file, prod",
+    name: "require .js AST, prod",
     fn: () => {
       const ast = require('./react-dom.production.min.js');
       delete require.cache[require.resolve('./react-dom.production.min.js')];
     }
   },
   "require-json-prod": {
-    name: "require .json file, prod",
+    name: "require .json AST, prod",
     fn: () => {
-      const ast = require('./react-dom.production.min.json');
-      delete require.cache[require.resolve('./react-dom.production.min.json')];
+      const ast = require('./react-dom.production.min-json');
+      delete require.cache[require.resolve('./react-dom.production.min-json')];
     }
   },
   "read-json-prod": {
-    name: "read .json file, prod",
+    name: "read .json AST, prod",
     fn: () => {
-      const ast = JSON.parse(fs.readFileSync('./react-dom.production.min.json'));
+      const ast = JSON.parse(fs.readFileSync('./react-dom.production.min-json.json'));
     }
   },
   "read-json-fast-prod": {
-    name: "read .json file fast parse, prod",
+    name: "read .json AST fast parse, prod",
     fn: () => {
-      const ast = fastJsonParse(fs.readFileSync('./react-dom.production.min.json'));
+      const ast = fastJsonParse(fs.readFileSync('./react-dom.production.min-json.json'));
     }
   },
   "parse-dev": {
-    name: "parse JS code, dev",
+    name: "parse .js code, dev",
     fn: () => {
       const dev = fs.readFileSync(ReactDOMDev, 'utf8');
       const devAst = babylon.parse(prod);
     }
   },
-  "require-ast-dev": {
-    name: "require .ast file, dev",
-    fn: () => {
-      const ast = require('./react-dom.development.ast');
-      delete require.cache[require.resolve('./react-dom.development.ast')];
-    }
-  },
   "require-js-dev": {
-    name: "require .js file, dev",
+    name: "require .js AST, dev",
     fn: () => {
       const ast = require('./react-dom.development.js');
       delete require.cache[require.resolve('./react-dom.development.js')];
     }
   },
   "require-json-dev": {
-    name: "require .json file, dev",
+    name: "require .json AST, dev",
     fn: () => {
-      const ast = require('./react-dom.development.json');
-      delete require.cache[require.resolve('./react-dom.development.json')];
+      const ast = require('./react-dom.development-json');
+      delete require.cache[require.resolve('./react-dom.development-json')];
     }
   },
   "read-json-dev": {
-    name: "read .json file, dev",
+    name: "read .json AST, dev",
     fn: () => {
-      const ast = JSON.parse(fs.readFileSync('./react-dom.development.json'));
+      const ast = JSON.parse(fs.readFileSync('./react-dom.development-json.json'));
     }
   },
   "read-json-fast-dev": {
-    name: "read .json file fast parse, dev",
+    name: "read .json AST fast parse, dev",
     fn: () => {
-      const ast = fastJsonParse(fs.readFileSync('./react-dom.development.json'));
+      const ast = fastJsonParse(fs.readFileSync('./react-dom.development-json.json'));
     }
   },
 }

--- a/run.js
+++ b/run.js
@@ -65,7 +65,7 @@ const benchmarkFns = {
     }
   },
   "read-json-fast-prod": {
-    name: "read .json file, prod",
+    name: "read .json file fast parse, prod",
     fn: () => {
       const ast = fastJsonParse(fs.readFileSync('./react-dom.production.min.json'));
     }
@@ -105,7 +105,7 @@ const benchmarkFns = {
     }
   },
   "read-json-fast-dev": {
-    name: "read .json file, dev",
+    name: "read .json file fast parse, dev",
     fn: () => {
       const ast = fastJsonParse(fs.readFileSync('./react-dom.development.json'));
     }


### PR DESCRIPTION
I tried converting this benchmark over to benchmark.js, because in my experience it tends to give better, more reproducible results, especially where JIT is concerned.

There are a few ugly caveats here:

- Running `require` multiple times in a row is a wildly unfair way to benchmark, as `require` caches modules that have been previously required. To fix this, I delete the module out of the require cache at the end of each test, but it should be noted that this then adds slightly to the test time of any version that uses `require`.
- Much worse that than that, it seems that deleting out of the require cache repeatedly can cause [massive memory leaks](https://github.com/nodejs/node-v0.x-archive/issues/6176). I found that running more than one test that tries deleting out of the require cache will cause an out of memory error.
- To fix that, I run each test in a separate node process. This usually means that we don't get out of memory errors (though sometimes they still crop up!). The node processes frequently gobble up more than 1GB of memory, though, and I wouldn't be surprised if this is biasing the tests against the `require` versions.

So, you know, there are caveats.

However! It seems like reading a file and using JSON.parse is only around 5-15% better than `require`ing the JSON file, which would indicate that the memory leak is not wildly affecting the results.

Some observations:

- Parsing the code seems best by a wide margin, though not quite as wide as the original version of the tests (caveats notwithstanding).
- Requiring a `.js` version seems better than requiring a `.json` version.
- Reading a file and calling `JSON.parse` seems marginally better than `require`ing JSON, but only by 5-15%, which could easily be because of the memory leak.
- `fast-json-parse` seems just about the same as `JSON.parse`.

Thoughts?